### PR TITLE
Add patch to fix broken UTF-8 with perl-5.38

### DIFF
--- a/broken-perl-5.38.patch
+++ b/broken-perl-5.38.patch
@@ -1,0 +1,11 @@
+--- rxvt-unicode-9.31.old/src/rxvtperl.xs	2022-12-30 20:18:20.000000000 +0100
++++ rxvt-unicode-9.31/src/rxvtperl.xs	2023-07-08 16:26:46.086347986 +0200
+@@ -399,7 +399,7 @@
+ {
+   if (!perl)
+     {
+-      rxvt_push_locale (""); // perl init destroys current locale
++      rxvt_push_locale ("C"); // perl init destroys current locale
+ 
+       {
+         perl_environ = rxvt_environ;

--- a/urxvt.spec
+++ b/urxvt.spec
@@ -7,12 +7,13 @@ Summary:	Rxvt terminal with unicode support and some improvements
 Summary(pl.UTF-8):	Terminal Rxvt z obsługą unicode i kilkoma usprawnieniami
 Name:		urxvt
 Version:	9.31
-Release:	2
+Release:	3
 License:	GPL v3+
 Group:		X11/Applications
 Source0:	http://dist.schmorp.de/rxvt-unicode/rxvt-unicode-%{version}.tar.bz2
 # Source0-md5:	3d0ec83705c9b9ff301a4b9965b3cd9f
 Source1:	%{name}.desktop
+Patch0:		broken-perl-5.38.patch
 URL:		http://software.schmorp.de/
 BuildRequires:	autoconf >= 2.71
 BuildRequires:	automake
@@ -52,6 +53,7 @@ URxvt jest modyfikacją Rxvt uwzględniającą:
 
 %prep
 %setup -q -n rxvt-unicode-%{version}
+%patch0 -p1
 
 %build
 %{__aclocal} -I.


### PR DESCRIPTION
It seems that after rebuilding urxvt with perl-5.38 UTF-8 stopped to work.  Analysis of the bug was done by sxzzsf and patch sent to rxvt-unicode mailing list: http://lists.schmorp.de/pipermail/rxvt-unicode/2023q3/002665.html 

My PR incorporates the patch and applies it during building.